### PR TITLE
Fixed ujson issue on Ubuntu 18.04

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,5 +35,5 @@ redis==2.10.6
 setproctitle==1.1.10
 six==1.11.0
 tox==2.9.1
-ujson==1.35
+ujson==2.0.3
 virtualenv==15.1.0


### PR DESCRIPTION
Looks like ultrajson doesn't work with Ubuntu 18.
Check the issue https://github.com/ultrajson/ultrajson/issues/346

So I upgraded ujson dependency version to the latest one.
It seems working well, here is a working demo on Ubuntu 18.04 server:
https://stats.soldat-tr.com/ctf
